### PR TITLE
BUG: on home page

### DIFF
--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -24,7 +24,7 @@ const About = () => {
       </motion.div>
 
       <div className="container mx-auto h-full flex flex-col items-center xl:flex-row gap-x-6">
-        <div className="flex-1 flex flex-col justify-center">
+        <div className="flex-1 flex flex-col justify-center xl:mt-20">
           <motion.h2
             variants={fadeIn("right", 0.2)}
             initial="hidden"


### PR DESCRIPTION
[Bug] Text overlaps the heading "Competent in Global/Local People Management"

# Title

Closes <!-- GitHub ticket number #13 -->

## Description

Please describe what did you built or fixed?

added margin-top to overcome the overlapping of text

## Screenshot
![image](https://github.com/user-attachments/assets/2ffb2aa9-70dd-4d03-9cc8-ed59599b806a)

Could you please drop a screenshot of your feature or fix?
![image](https://github.com/user-attachments/assets/287c675f-22ff-40e4-b6cd-05ef09fd27c9)

## Steps to Verify

Please walk through how to verify and test this feature or fix.
To better understand and address the problem:

1. Open your website in a browser and navigate to the About section.
2. Observe the text animation "Competent in Executive Leadership |."
3. Modify the animation or add enough text to make it span three lines.
4. Confirm the overlap issue between the heading and the animated text.

